### PR TITLE
Separate `Node_t*` and `Handle_t`

### DIFF
--- a/benchmarks/bench_lru.cpp
+++ b/benchmarks/bench_lru.cpp
@@ -13,21 +13,21 @@ void test() {
 
   auto h1 = cache.insert(1, 1001, true);
   assert(h1);
-  h1->value = 111;
+  *h1 = 111;
   auto h2 = cache.insert(2, 1002, true);
   assert(h2);
-  h2->value = 222;
+  *h1 = 222;
   auto h3 = cache.insert(3, 1003, true);
   assert(h3);
-  h3->value = 333;
+  *h1 = 333;
   auto h4 = cache.insert(4, 1004);
   assert(h4);
-  h4->value = 444;
+  *h1 = 444;
   std::cout << "=== Expect: lru: [4], in_use: [1, 2, 3] ===\n";
   std::cout << cache;
 
   h4 = cache.lookup(4, 1004, true);
-  h4->value = 4444;
+  *h4 = 4444;
   std::cout << "=== Expect: lru: [], in_use: [1, 2, 3, 4] ===\n";
   std::cout << cache;
 
@@ -38,7 +38,7 @@ void test() {
   cache.release(h3);
   h5 = cache.insert(5, 1005, true);
   assert(h5);
-  h5->value = 555;
+  *h5 = 555;
   std::cout << "\n=== Expect: in_use: [1, 2, 4, 5] ===\n";
   std::cout << cache;
 
@@ -50,7 +50,7 @@ void test() {
 
   h3 = cache.insert(3, 1003, true);
   assert(h3);
-  h3->value = 3333;
+  *h3 = 3333;
   h5 = cache.lookup(5, 1005, true);
   std::cout << "\n=== Expect: lru: [2, 4], in_use: [1, 3] ===\n";
   std::cout << cache;
@@ -63,13 +63,13 @@ void test() {
 
   auto h6 = cache.insert(6, 1006, true);
   assert(h6);
-  h6->value = 666;
+  *h6 = 666;
   std::cout << "\n=== Expect: lru: [], in_use: [1, 3, 5, 6] ===\n";
   std::cout << cache;
 
   auto h5_ = cache.insert(5, 1005, true);
   assert(h5_ == h5);
-  h5_->value = 5555;
+  *h5_ = 5555;
   std::cout << "\n=== Expect: lru: [], in_use: [1, 3, 5, 6] ===\n";
   std::cout << cache;
 
@@ -94,7 +94,7 @@ void test() {
 
   h7 = cache.insert(7, 1007);
   assert(h7);
-  h7->value = 777;
+  *h7 = 777;
   std::cout << "\n=== Expect: lru: [3, 6, 5, 7], in_use: [] ===\n";
   std::cout << cache;
   std::cout << std::flush;

--- a/benchmarks/bench_shared.cpp
+++ b/benchmarks/bench_shared.cpp
@@ -16,33 +16,33 @@ void test1() {
 
   auto h = shared_cache.insert(537, 1, 1001, true);
   assert(h);
-  shared_cache.get_value(h) = 111;
+  *h = 111;
   shared_cache.release(h);
   h = shared_cache.insert(564, 2, 1002, false);
   assert(h);
-  shared_cache.get_value(h) = 222;
+  *h = 222;
   h = shared_cache.insert(537, 3, 1003, false);
   assert(h);
-  shared_cache.get_value(h) = 333;
+  *h = 333;
 
   std::cout << "Expect: { 564: [2], 537: [1, 3]}" << std::endl;
   std::cout << shared_cache << std::endl;
 
   h = shared_cache.insert(564, 4, 1004, false);
   assert(h);
-  shared_cache.get_value(h) = 444;
+  *h = 444;
   h = shared_cache.insert(537, 5, 1005, false);
   assert(h);
-  shared_cache.get_value(h) = 555;
+  *h = 555;
   std::cout << "Expect: { 564: [2, 4], 537: [1, 3, 5] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
   h = shared_cache.insert(564, 6, 1006, false);
   assert(h);
-  shared_cache.get_value(h) = 666;
+  *h = 666;
   h = shared_cache.insert(537, 2, 1002, false);
   assert(h);
-  shared_cache.get_value(h) = 2222;
+  *h = 2222;
   std::cout << "Expect: { 564: [4, 6], 537: [3, 5, 2] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
@@ -50,7 +50,7 @@ void test1() {
   // expect to just return the existing one
   h = shared_cache.insert(564, 2, 1002, false);
   assert(h);
-  shared_cache.get_value(h) = 22222;
+  *h = 22222;
   std::cout << "Expect: { 564: [4, 6], 537: [3, 5, 2] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
@@ -60,16 +60,16 @@ void test1() {
 
   h = shared_cache.insert(564, 7, 1007, false);
   assert(h);
-  shared_cache.get_value(h) = 777;
+  *h = 777;
   h = shared_cache.insert(564, 8, 1008, false);
   assert(h);
-  shared_cache.get_value(h) = 888;
+  *h = 888;
   std::cout << "Expect: { 564: [4, 6, 7, 8], 537: [2] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
   h = shared_cache.insert(564, 9, 1009, false);
   assert(h);
-  shared_cache.get_value(h) = 999;
+  *h = 999;
   std::cout << "Expect: { 564: [6, 7, 8, 9], 537: [2] }" << std::endl;
   std::cout << shared_cache << std::endl;
 }

--- a/include/gcache/handle.h
+++ b/include/gcache/handle.h
@@ -27,24 +27,30 @@ namespace gcache {
 // when they detect an element in the cache acquiring or losing its only
 // external reference.
 
-template <typename Key_t, typename Value_t>
+template <typename Node_t>
 class HandleTable;
-template <typename Key_t, typename Value_t>
+template <typename Key_t, typename Value_t, typename Tag_t>
 class LRUCache;
 class GhostCache;
 
-// An entry is a variable length heap-allocated structure.  Entries
-// are kept in a circular doubly linked list ordered by access time.
-template <typename Key_t, typename Value_t>
-class LRUHandle {
- private:
-  LRUHandle* next_hash;
-  LRUHandle* next;
-  LRUHandle* prev;
+template <typename Tag_t>
+struct TagWrapper {
+  Tag_t tag;
+};
+
+template <>
+struct TagWrapper<nullptr_t> {};
+
+// LRUNodes forms a circular doubly linked list ordered by access time.
+template <typename Key_t, typename Value_t, typename Tag_t = nullptr_t>
+class LRUNode : public TagWrapper<Tag_t> {
+  LRUNode *next_hash;
+  LRUNode *next;
+  LRUNode *prev;
   uint32_t refs;  // References, including cache reference, if present.
 
-  friend class HandleTable<Key_t, Value_t>;
-  friend class LRUCache<Key_t, Value_t>;
+  friend class HandleTable<LRUNode>;
+  friend class LRUCache<Key_t, Value_t, Tag_t>;
   friend class GhostCache;
 
  public:
@@ -52,28 +58,36 @@ class LRUHandle {
   Key_t key;
   Value_t value;
 
-  void init(Key_t key, uint32_t hash) {
+  using key_type = Key_t;
+  using value_type = Value_t;
+
+  void init(Key_t k, uint32_t h) {
     this->refs = 1;
-    this->hash = hash;
-    this->key = key;
+    this->hash = h;
+    this->key = k;
   }
 
   // print for debugging
-  friend std::ostream& operator<<(std::ostream& os, const LRUHandle& h) {
-    return os << h.key << ": " << h.value << " (refs=" << h.refs
-              << ", hash=" << h.hash << ")";
+  friend std::ostream &operator<<(std::ostream &os, const LRUNode &h) {
+    if constexpr (std::is_same_v<Tag_t, nullptr_t>) {
+      return os << h.key << ": " << h.value << " (refs=" << h.refs
+                << ", hash=" << h.hash << ")";
+    } else {
+      return os << h.key << ": " << h.value << " (refs=" << h.refs
+                << ", hash=" << h.hash << ", tag=" << h.tag << ")";
+    }
   }
 
   template <typename Fn>
   void for_each(Fn fn) {
     fn(this->key, this);
-    for (LRUHandle* h = next; h != this; h = h->next) {
+    for (LRUNode *h = next; h != this; h = h->next) {
       fn(h->key, h);
     }
   }
 
   // print a list; this must be a dummy list head
-  std::ostream& print_list(std::ostream& os) const {
+  std::ostream &print_list(std::ostream &os) const {
     auto h = next;
     if (h == this) return os;
     os << h->key;
@@ -87,7 +101,7 @@ class LRUHandle {
     return os;
   }
 
-  std::ostream& print_list_hash(std::ostream& os) const {
+  std::ostream &print_list_hash(std::ostream &os) const {
     auto h = this;
     while (h) {
       os << '\t' << *h << ';';
@@ -97,4 +111,48 @@ class LRUHandle {
     return os;
   }
 };
+
+// make sure that Tag_t does not occupy space if it is not provided
+static_assert(sizeof(LRUNode<int, int>) == 40);
+static_assert(sizeof(LRUNode<int, int, int>) == 48);
+
+// LRUHandle is essentially just LRUNode*.
+// Use LRUHandle for public APIs as it's easier to access the value.
+// Use LRUNode* for internal APIs as it's easier to access internal fields.
+template <typename Node_t>
+struct LRUHandle {
+  LRUHandle() = default;
+  LRUHandle(const LRUHandle &) = default;
+  LRUHandle(LRUHandle &&) noexcept = default;
+  LRUHandle &operator=(const LRUHandle &) = default;
+  LRUHandle &operator=(LRUHandle &&) noexcept = default;
+
+  LRUHandle(Node_t *node) : node(node) {}
+
+  // overload -> and *
+  Node_t::value_type *operator->() { return &node->value; }
+  const Node_t::value_type *operator->() const { return &node->value; }
+  Node_t::value_type &operator*() { return node->value; }
+
+  // overload bool
+  explicit operator bool() const { return node != nullptr; }
+
+  // overload == and !=
+  bool operator==(std::nullptr_t) const { return node == nullptr; }
+  bool operator!=(std::nullptr_t) const { return node != nullptr; }
+  bool operator==(const LRUHandle &other) const { return node == other.node; }
+  bool operator!=(const LRUHandle &other) const { return node != other.node; }
+
+  Node_t *node = nullptr;
+};
+static_assert(sizeof(LRUHandle<LRUNode<int, int>>) == 8);
 }  // namespace gcache
+
+namespace std {
+template <typename Node_t>
+struct hash<gcache::LRUHandle<Node_t>> {
+  std::size_t operator()(const gcache::LRUHandle<Node_t> &h) const {
+    return std::hash<void *>()(h.node);
+  }
+};
+}  // namespace std

--- a/include/gcache/handle_table.h
+++ b/include/gcache/handle_table.h
@@ -18,58 +18,58 @@ namespace gcache {
 // table implementations in some of the compiler/runtime combinations
 // we have tested.  E.g., readrandom speeds up by ~5% over the g++
 // 4.4.3's builtin hashtable.
-template <typename Key_t, typename Value_t>
+template <typename Node_t>
 class HandleTable {
+  using Key_t = Node_t::key_type;
  public:
-  typedef LRUHandle<Key_t, Value_t> Handle_t;
   HandleTable() : length_(0), list_(nullptr) {}
   ~HandleTable() { delete[] list_; }
 
   void init(size_t size);  // size must be 2^n; must be called before any r/w
 
   // Caller must ensure e's key does not already present in table!
-  void insert(Handle_t* e);
-  Handle_t* lookup(Key_t key, uint32_t hash);
-  Handle_t* remove(Key_t key, uint32_t hash);
+  void insert(Node_t* e);
+  Node_t* lookup(Key_t key, uint32_t hash);
+  Node_t* remove(Key_t key, uint32_t hash);
 
  private:
   // Return a pointer to slot that points to a cache entry that
   // matches key/hash.  If there is no such cache entry, return a
   // pointer to the trailing slot in the corresponding linked list.
-  Handle_t** find_pointer(Key_t key, uint32_t hash);
+  Node_t** find_pointer(Key_t key, uint32_t hash);
 
   // The table consists of an array of buckets where each bucket is
   // a linked list of cache entries that hash into the bucket.
   uint32_t length_;
-  Handle_t** list_;
+  Node_t** list_;
 
  public:  // for debugging
   std::ostream& print(std::ostream& os, int indent = 0) const;
 };
 
-template <typename Key_t, typename Value_t>
-inline void HandleTable<Key_t, Value_t>::insert(Handle_t* e) {
+template <typename Node_t>
+inline void HandleTable<Node_t>::insert(Node_t* e) {
   // Caller must ensure e->key is not present in the table!
   assert(!lookup(e->key, e->hash));
   // Add to the head of this linked list
-  Handle_t** ptr = &list_[e->hash & (length_ - 1)];
+  Node_t** ptr = &list_[e->hash & (length_ - 1)];
   e->next_hash = *ptr;
   *ptr = e;
 }
 
-template <typename Key_t, typename Value_t>
-inline typename HandleTable<Key_t, Value_t>::Handle_t*
-HandleTable<Key_t, Value_t>::lookup(Key_t key, uint32_t hash) {
+template <typename Node_t>
+inline Node_t*
+HandleTable<Node_t>::lookup(Key_t key, uint32_t hash) {
   assert(length_ > 0);
   return *find_pointer(key, hash);
 }
 
-template <typename Key_t, typename Value_t>
-inline typename HandleTable<Key_t, Value_t>::Handle_t*
-HandleTable<Key_t, Value_t>::remove(Key_t key, uint32_t hash) {
+template <typename Node_t>
+inline Node_t*
+HandleTable<Node_t>::remove(Key_t key, uint32_t hash) {
   assert(length_ > 0);
-  Handle_t** ptr = find_pointer(key, hash);
-  Handle_t* result = *ptr;
+  Node_t** ptr = find_pointer(key, hash);
+  Node_t* result = *ptr;
   if (result != nullptr) *ptr = result->next_hash;
   return result;
 }
@@ -77,26 +77,26 @@ HandleTable<Key_t, Value_t>::remove(Key_t key, uint32_t hash) {
 // Return a pointer to slot that points to a cache entry that
 // matches key/hash.  If there is no such cache entry, return a
 // pointer to the trailing slot in the corresponding linked list.
-template <typename Key_t, typename Value_t>
-inline typename HandleTable<Key_t, Value_t>::Handle_t**
-HandleTable<Key_t, Value_t>::find_pointer(Key_t key, uint32_t hash) {
-  Handle_t** ptr = &list_[hash & (length_ - 1)];
+template <typename Node_t>
+inline Node_t**
+HandleTable<Node_t>::find_pointer(Key_t key, uint32_t hash) {
+  Node_t** ptr = &list_[hash & (length_ - 1)];
   while (*ptr != nullptr && ((*ptr)->hash != hash || key != (*ptr)->key)) {
     ptr = &(*ptr)->next_hash;
   }
   return ptr;
 }
 
-template <typename Key_t, typename Value_t>
-inline void HandleTable<Key_t, Value_t>::init(size_t size) {
+template <typename Node_t>
+inline void HandleTable<Node_t>::init(size_t size) {
   size = std::bit_ceil<size_t>(size);
   length_ = size;
-  list_ = new Handle_t*[length_];
+  list_ = new Node_t*[length_];
   memset(list_, 0, sizeof(list_[0]) * length_);
 }
 
-template <typename Key_t, typename Value_t>
-inline std::ostream& HandleTable<Key_t, Value_t>::print(std::ostream& os,
+template <typename Node_t>
+inline std::ostream& HandleTable<Node_t>::print(std::ostream& os,
                                                         int indent) const {
   os << "HandleTable (length=" << length_ << ") {\n";
   for (size_t i = 0; i < length_; ++i) {

--- a/include/gcache/lru_cache.h
+++ b/include/gcache/lru_cache.h
@@ -17,10 +17,11 @@ class GhostCache;
 
 // Key_t should be lightweight that can be pass-by-value
 // Value_t should be trivially copyable
-template <typename Key_t, typename Value_t>
+template <typename Key_t, typename Value_t, typename Tag_t = nullptr_t>
 class LRUCache {
  public:
-  typedef LRUHandle<Key_t, Value_t> Handle_t;
+  using Node_t = LRUNode<Key_t, Value_t, Tag_t>;
+  using Handle_t = LRUHandle<Node_t>;
   LRUCache();
   ~LRUCache();
   LRUCache(const LRUCache&) = delete;
@@ -41,20 +42,20 @@ class LRUCache {
   // Insert a handle into cache with given key and hash if not exists; if does,
   // return the existing one; if it is known for sure that the key must not
   // exist, set not_exist to true to skip a lookup
-  Handle_t* insert(Key_t key, uint32_t hash, bool pin = false,
-                   bool not_exist = false);
+  Handle_t insert(Key_t key, uint32_t hash, bool pin = false,
+                  bool not_exist = false);
   // Search for a handle; return nullptr if not exist
-  Handle_t* lookup(Key_t key, uint32_t hash, bool pin = false);
+  Handle_t lookup(Key_t key, uint32_t hash, bool pin = false);
   // Release pinned handle returned by insert/lookup
-  void release(Handle_t* handle);
+  void release(Handle_t handle);
   // Evict a handle from cache, w/o adding it to the free list
-  void evict(Handle_t* handle);
+  void evict(Handle_t handle);
   // Pin a handle returned by insert/lookup
-  void pin(Handle_t* handle);
+  void pin(Handle_t handle);
   // Similar to insert but 1) never pin and the targeted handle must be in LRU
   // list, 2) return `successor`: the handle with the same order as the returned
   // handle after LRU operations (nullptr if newly inserted).
-  Handle_t* touch(Key_t key, uint32_t hash, Handle_t*& successor);
+  Handle_t touch(Key_t key, uint32_t hash, Handle_t& successor);
 
   /****************************************************************************/
   /* Below are intrusive functions that should only be called by SharedCache  */
@@ -62,31 +63,30 @@ class LRUCache {
 
   // Init handle pool and table from externally instantiated ones but not owned
   // them; the caller must free the pool and table after dtor
-  void init_from(Handle_t* pool, HandleTable<Key_t, Value_t>* table,
-                 size_t capacity);
+  void init_from(Node_t* pool, HandleTable<Node_t>* table, size_t capacity);
 
   // Force this cache to return a handle (i.e. a cache slot) back to caller;
   // will try to return from free list first; if not available, preempt from
   // lru_ instead; if still not available, return nullptr
-  Handle_t* preempt();
+  Handle_t preempt();
 
   // Assign a new handle to this LRUCache; will be put into free list (duel with
   // `preempt`)
-  void assign(Handle_t* e);
+  void assign(Handle_t e);
 
-  void try_refresh(Handle_t* e, bool pin);
+  void try_refresh(Handle_t e, bool pin);
 
  private:
   friend GhostCache;
-  Handle_t* alloc_handle();
-  void free_handle(Handle_t* e);
-  void list_remove(Handle_t* e);
-  void list_append(Handle_t* list, Handle_t* e);
-  void ref(Handle_t* e);
-  void unref(Handle_t* e);
+  Node_t* alloc_handle();
+  void free_handle(Node_t* e);
+  void list_remove(Node_t* e);
+  void list_append(Node_t* list, Node_t* e);
+  void ref(Node_t* e);
+  void unref(Node_t* e);
   // Perform LRU operation and return the handle with the same order in the list
   // after LRU (usually it's e->next)
-  Handle_t* lru_refresh(Handle_t* e);
+  Node_t* lru_refresh(Node_t* e);
 
   // Initialized before use.
   size_t capacity_;
@@ -95,24 +95,24 @@ class LRUCache {
   // Allocate a handle from free_ and put it into table_; a handle in table_
   // must either present in lru_ or in_use_
   // If user calls `init_from`, this field will be nullptr
-  Handle_t* pool_;
+  Node_t* pool_;
 
   // Hash table to lookup
   // If user calls `init_from`, this field will just refer to the external one;
   // otherwise, managed by this class instance
-  HandleTable<Key_t, Value_t>* table_;
+  HandleTable<Node_t>* table_;
 
   // Dummy head of LRU list.
   // lru.prev is the newest entry, lru.next is the oldest entry.
   // Entries have refs==1.
-  Handle_t lru_;
+  Node_t lru_;
 
   // Dummy head of in-use list.
   // Entries are in use by clients and have refs >= 2.
-  Handle_t in_use_;
+  Node_t in_use_;
 
   // Dummy head of free list.
-  Handle_t free_;
+  Node_t free_;
 
  public:  // for debugging
   std::ostream& print(std::ostream& os, int indent = 0) const;
@@ -121,8 +121,8 @@ class LRUCache {
   }
 };
 
-template <typename Key_t, typename Value_t>
-inline LRUCache<Key_t, Value_t>::LRUCache()
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline LRUCache<Key_t, Value_t, Tag_t>::LRUCache()
     : capacity_(0), pool_(nullptr), table_(nullptr) {
   // Make empty circular linked lists.
   lru_.next = &lru_;
@@ -132,8 +132,8 @@ inline LRUCache<Key_t, Value_t>::LRUCache()
   // free_ will be initialized when init() is called
 }
 
-template <typename Key_t, typename Value_t>
-inline LRUCache<Key_t, Value_t>::~LRUCache() {
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline LRUCache<Key_t, Value_t, Tag_t>::~LRUCache() {
   assert(in_use_.next == &in_use_);  // Error if caller has an unreleased handle
   // if pool_ is nullptr, then this instance is initialized from `init_from` not
   // `init`, which means it owns neither pool_ nor table_. In this case, all
@@ -141,19 +141,19 @@ inline LRUCache<Key_t, Value_t>::~LRUCache() {
   if (pool_) {
     // if pool_ is
     // Unnecessary for correctness, but kept to ease debugging
-    for (const Handle_t* e = lru_.next; e != &lru_; e = e->next)
+    for (const Node_t* e = lru_.next; e != &lru_; e = e->next)
       assert(e->refs == 1);  // Invariant of lru_ list.
     delete[] pool_;
     delete table_;
   }
 }
 
-template <typename Key_t, typename Value_t>
-inline void LRUCache<Key_t, Value_t>::init(size_t capacity) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline void LRUCache<Key_t, Value_t, Tag_t>::init(size_t capacity) {
   assert(!capacity_ && !pool_ && !table_);
   assert(capacity);
   capacity_ = capacity;
-  pool_ = new Handle_t[capacity];
+  pool_ = new Node_t[capacity];
   // Put these entries into free list
   free_.next = &pool_[0];
   pool_[0].prev = &free_;
@@ -163,30 +163,29 @@ inline void LRUCache<Key_t, Value_t>::init(size_t capacity) {
     pool_[i].next = &pool_[i + 1];
     pool_[i + 1].prev = &pool_[i];
   }
-  table_ = new HandleTable<Key_t, Value_t>();
+  table_ = new HandleTable<Node_t>();
   table_->init(capacity);
 }
 
-template <typename Key_t, typename Value_t>
+template <typename Key_t, typename Value_t, typename Tag_t>
 template <typename Fn>
-inline void LRUCache<Key_t, Value_t>::init(size_t capacity, Fn&& fn) {
+inline void LRUCache<Key_t, Value_t, Tag_t>::init(size_t capacity, Fn&& fn) {
   init(capacity);
   for (size_t i = 0; i < capacity; ++i) {
     fn(&pool_[i]);
   }
 }
 
-template <typename Key_t, typename Value_t>
+template <typename Key_t, typename Value_t, typename Tag_t>
 template <typename Fn>
-inline void LRUCache<Key_t, Value_t>::for_each(Fn&& fn) {
+inline void LRUCache<Key_t, Value_t, Tag_t>::for_each(Fn&& fn) {
   in_use_.for_each(fn);
   lru_.for_each(fn);
 }
 
-template <typename Key_t, typename Value_t>
-inline void LRUCache<Key_t, Value_t>::init_from(
-    typename LRUCache<Key_t, Value_t>::Handle_t* pool,
-    HandleTable<Key_t, Value_t>* table, size_t capacity) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline void LRUCache<Key_t, Value_t, Tag_t>::init_from(
+    Node_t* pool, HandleTable<Node_t>* table, size_t capacity) {
   assert(!capacity_ && !pool_ && !table_);
   assert(capacity);
   capacity_ = capacity;
@@ -202,18 +201,18 @@ inline void LRUCache<Key_t, Value_t>::init_from(
   table_ = table;
 }
 
-template <typename Key_t, typename Value_t>
-inline typename LRUCache<Key_t, Value_t>::Handle_t*
-LRUCache<Key_t, Value_t>::insert(Key_t key, uint32_t hash, bool pin,
-                                 bool not_exist) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline typename LRUCache<Key_t, Value_t, Tag_t>::Handle_t
+LRUCache<Key_t, Value_t, Tag_t>::insert(Key_t key, uint32_t hash, bool pin,
+                                        bool not_exist) {
   // Disable support for capacity_ == 0; the user must set capacity first
   assert(capacity_ > 0);
 
   // Search to see if already exists
-  Handle_t* e;
+  Node_t* e;
 
   if (!not_exist) {  // if not sure whether the key exists, do lookup
-    e = lookup(key, hash, pin);
+    e = lookup(key, hash, pin).node;
     if (e) return e;
   }
 
@@ -231,39 +230,40 @@ LRUCache<Key_t, Value_t>::insert(Key_t key, uint32_t hash, bool pin,
   return e;
 }
 
-template <typename Key_t, typename Value_t>
-inline typename LRUCache<Key_t, Value_t>::Handle_t*
-LRUCache<Key_t, Value_t>::lookup(Key_t key, uint32_t hash, bool pin) {
-  Handle_t* e = table_->lookup(key, hash);
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline typename LRUCache<Key_t, Value_t, Tag_t>::Handle_t
+LRUCache<Key_t, Value_t, Tag_t>::lookup(Key_t key, uint32_t hash, bool pin) {
+  Handle_t e = table_->lookup(key, hash);
   if (e) try_refresh(e, pin);
   return e;
 }
 
-template <typename Key_t, typename Value_t>
-inline void LRUCache<Key_t, Value_t>::release(Handle_t* handle) {
-  unref(handle);
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline void LRUCache<Key_t, Value_t, Tag_t>::release(Handle_t handle) {
+  unref(handle.node);
 }
 
-template <typename Key_t, typename Value_t>
-inline void LRUCache<Key_t, Value_t>::pin(Handle_t* handle) {
-  ref(handle);
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline void LRUCache<Key_t, Value_t, Tag_t>::pin(Handle_t handle) {
+  ref(handle.node);
 }
 
-template <typename Key_t, typename Value_t>
-inline void LRUCache<Key_t, Value_t>::evict(Handle_t* handle) {
-  handle->refs = 0;
-  list_remove(handle);
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline void LRUCache<Key_t, Value_t, Tag_t>::evict(Handle_t handle) {
+  Node_t* e = handle.node;
+  e->refs = 0;
+  list_remove(e);
 }
 
-template <typename Key_t, typename Value_t>
-inline typename LRUCache<Key_t, Value_t>::Handle_t*
-LRUCache<Key_t, Value_t>::touch(Key_t key, uint32_t hash,
-                                Handle_t*& successor) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline typename LRUCache<Key_t, Value_t, Tag_t>::Handle_t
+LRUCache<Key_t, Value_t, Tag_t>::touch(Key_t key, uint32_t hash,
+                                       Handle_t& successor) {
   // Disable support for capacity_ == 0; the user must set capacity first
   assert(capacity_ > 0);
 
   // Search to see if already exists
-  Handle_t* e = table_->lookup(key, hash);
+  Node_t* e = table_->lookup(key, hash);
   if (e) {
     successor = lru_refresh(e);
     return e;
@@ -279,9 +279,9 @@ LRUCache<Key_t, Value_t>::touch(Key_t key, uint32_t hash,
   return e;
 }
 
-template <typename Key_t, typename Value_t>
-typename LRUCache<Key_t, Value_t>::Handle_t*
-LRUCache<Key_t, Value_t>::preempt() {
+template <typename Key_t, typename Value_t, typename Tag_t>
+typename LRUCache<Key_t, Value_t, Tag_t>::Handle_t
+LRUCache<Key_t, Value_t, Tag_t>::preempt() {
   // In fact, it is just like allocate a handle but instead of using it
   // immediately, return it out to caller (i.e. SharedCache)
   // We keep this function independent from `alloc_handle` to make it
@@ -289,13 +289,14 @@ LRUCache<Key_t, Value_t>::preempt() {
   return alloc_handle();
 }
 
-template <typename Key_t, typename Value_t>
-void LRUCache<Key_t, Value_t>::assign(Handle_t* e) {
-  free_handle(e);
+template <typename Key_t, typename Value_t, typename Tag_t>
+void LRUCache<Key_t, Value_t, Tag_t>::assign(Handle_t e) {
+  free_handle(e.node);
 }
 
-template <typename Key_t, typename Value_t>
-void LRUCache<Key_t, Value_t>::try_refresh(Handle_t* e, bool pin) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+void LRUCache<Key_t, Value_t, Tag_t>::try_refresh(Handle_t handle, bool pin) {
+  Node_t* e = handle.node;
   assert(e);
   if (pin)
     ref(e);
@@ -303,33 +304,33 @@ void LRUCache<Key_t, Value_t>::try_refresh(Handle_t* e, bool pin) {
     lru_refresh(e);
 }
 
-template <typename Key_t, typename Value_t>
-inline typename LRUCache<Key_t, Value_t>::Handle_t*
-LRUCache<Key_t, Value_t>::alloc_handle() {
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline LRUCache<Key_t, Value_t, Tag_t>::Node_t*
+LRUCache<Key_t, Value_t, Tag_t>::alloc_handle() {
   if (free_.next != &free_) {  // Allocate from free list
-    Handle_t* e = free_.next;
+    Node_t* e = free_.next;
     list_remove(e);
     return e;
   }
 
   // Evict one handle from LRU and recycle it
   if (lru_.next == &lru_) return nullptr;  // No more space
-  Handle_t* e = lru_.next;
+  Node_t* e = lru_.next;
   assert(e->refs == 1);
   list_remove(e);  // Remove from lru_
-  [[maybe_unused]] Handle_t* e_;
+  [[maybe_unused]] Node_t* e_;
   e_ = table_->remove(e->key, e->hash);
   assert(e_ == e);
   return e;
 }
 
-template <typename Key_t, typename Value_t>
-inline void LRUCache<Key_t, Value_t>::free_handle(Handle_t* e) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline void LRUCache<Key_t, Value_t, Tag_t>::free_handle(Node_t* e) {
   list_append(&free_, e);
 }
 
-template <typename Key_t, typename Value_t>
-inline void LRUCache<Key_t, Value_t>::ref(Handle_t* e) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline void LRUCache<Key_t, Value_t, Tag_t>::ref(Node_t* e) {
   if (e->refs == 1) {  // If on lru_ list, move to in_use_ list.
     list_remove(e);
     list_append(&in_use_, e);
@@ -337,8 +338,8 @@ inline void LRUCache<Key_t, Value_t>::ref(Handle_t* e) {
   e->refs++;
 }
 
-template <typename Key_t, typename Value_t>
-inline void LRUCache<Key_t, Value_t>::unref(Handle_t* e) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+inline void LRUCache<Key_t, Value_t, Tag_t>::unref(Node_t* e) {
   assert(e->refs > 0);
   e->refs--;
   if (e->refs == 0) {  // Deallocate.
@@ -350,14 +351,14 @@ inline void LRUCache<Key_t, Value_t>::unref(Handle_t* e) {
   }
 }
 
-template <typename Key_t, typename Value_t>
-void LRUCache<Key_t, Value_t>::list_remove(Handle_t* e) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+void LRUCache<Key_t, Value_t, Tag_t>::list_remove(Node_t* e) {
   e->next->prev = e->prev;
   e->prev->next = e->next;
 }
 
-template <typename Key_t, typename Value_t>
-void LRUCache<Key_t, Value_t>::list_append(Handle_t* list, Handle_t* e) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+void LRUCache<Key_t, Value_t, Tag_t>::list_append(Node_t* list, Node_t* e) {
   // Make "e" newest entry by inserting just before *list
   e->next = list;
   e->prev = list->prev;
@@ -365,9 +366,9 @@ void LRUCache<Key_t, Value_t>::list_append(Handle_t* list, Handle_t* e) {
   e->next->prev = e;
 }
 
-template <typename Key_t, typename Value_t>
-typename LRUCache<Key_t, Value_t>::Handle_t*
-LRUCache<Key_t, Value_t>::lru_refresh(Handle_t* e) {
+template <typename Key_t, typename Value_t, typename Tag_t>
+LRUCache<Key_t, Value_t, Tag_t>::Node_t*
+LRUCache<Key_t, Value_t, Tag_t>::lru_refresh(Node_t* e) {
   assert(e != &lru_);
   assert(e->refs == 1);
   auto successor = e->next;
@@ -377,9 +378,9 @@ LRUCache<Key_t, Value_t>::lru_refresh(Handle_t* e) {
   return successor;
 }
 
-template <typename Key_t, typename Value_t>
-std::ostream& LRUCache<Key_t, Value_t>::print(std::ostream& os,
-                                              int indent) const {
+template <typename Key_t, typename Value_t, typename Tag_t>
+std::ostream& LRUCache<Key_t, Value_t, Tag_t>::print(std::ostream& os,
+                                                     int indent) const {
   os << "LRUCache (capacity=" << capacity_ << ") {\n";
   for (int i = 0; i < indent + 1; ++i) os << '\t';
   os << "lru:    [";

--- a/include/gcache/shared_cache.h
+++ b/include/gcache/shared_cache.h
@@ -13,14 +13,9 @@ namespace gcache {
 template <typename Tag_t, typename Key_t, typename Value_t>
 class SharedCache {
  public:
-  struct TaggedValue_t {
-    Tag_t tag;
-    Value_t value;
-    friend std::ostream& operator<<(std::ostream& os, const TaggedValue_t& tv) {
-      return os << "(" << tv.tag << ", " << tv.value << ")";
-    }
-  };
-  typedef LRUHandle<Key_t, TaggedValue_t> Handle_t;
+  using Node_t = LRUNode<Key_t, Value_t, Tag_t>;
+  using Handle_t = LRUHandle<Node_t>;
+
   SharedCache() : pool_(nullptr), table_(), tenant_cache_map_(){};
   ~SharedCache() { delete[] pool_; };
   SharedCache(const SharedCache&) = delete;
@@ -39,19 +34,19 @@ class SharedCache {
 
   // Insert a handle into cache with given key and hash if not exists; if does,
   // return the existing one
-  Handle_t* insert(Tag_t tag, Key_t key, uint32_t hash, bool pin = false);
+  Handle_t insert(Tag_t tag, Key_t key, uint32_t hash, bool pin = false);
   // Search for a handle; return nullptr if not exist; no tag required because
   // there is no insertion may happen
   // FIXME: However, this op will refresh LRU list, so a tenant A could
   // repeatedly access a cache slot previously accessed by B and keep this slot
   // in memory, even though B does not use it anymore
-  Handle_t* lookup(Key_t key, uint32_t hash, bool pin = false);
+  Handle_t lookup(Key_t key, uint32_t hash, bool pin = false);
   // Release pinned handle returned by insert/lookup
-  void release(Handle_t* handle);
+  void release(Handle_t handle);
   // Pin a handle returned by insert/lookup
-  void pin(Handle_t* handle);
+  void pin(Handle_t handle);
   // Evict a handle from cache, w/o adding it to the free list
-  void evict(Handle_t* handle);
+  void evict(Handle_t handle);
   // `touch` is not implemented yet because it is mostly used on GhostCache and
   // it is unclear whether it is useful in the real cache
 
@@ -60,18 +55,13 @@ class SharedCache {
   // return; return number of handles relocated successfully
   size_t relocate(Tag_t src, Tag_t dst, size_t size);
 
-  // handle op wrappers
-  static Tag_t get_tag(Handle_t* e) { return e->value.tag; }
-  static Key_t get_key(Handle_t* e) { return e->value.key; }
-  static Value_t& get_value(Handle_t* e) { return e->value.value; }
-
  private:
-  Handle_t* pool_;
+  Node_t* pool_;
   size_t total_capacity_;
-  HandleTable<Key_t, TaggedValue_t> table_;
+  HandleTable<Node_t> table_;
 
   // Map each tenant's tag to its own cache; must be const after `init`
-  std::unordered_map<Tag_t, LRUCache<Key_t, TaggedValue_t>> tenant_cache_map_;
+  std::unordered_map<Tag_t, LRUCache<Key_t, Value_t, Tag_t>> tenant_cache_map_;
 
  public:  // for debugging
   std::ostream& print(std::ostream& os, int indent = 0) const;
@@ -88,7 +78,7 @@ void SharedCache<Tag_t, Key_t, Value_t>::init(
   for (auto [tag, capacity] : tenant_configs) total_capacity_ += capacity;
 
   table_.init(total_capacity_);
-  pool_ = new Handle_t[total_capacity_];
+  pool_ = new Node_t[total_capacity_];
   for (auto [tag, capacity] : tenant_configs) {
     tenant_cache_map_[tag].init_from(&pool_[begin_idx], &table_, capacity);
     begin_idx += capacity;
@@ -115,27 +105,27 @@ inline void SharedCache<Tag_t, Key_t, Value_t>::for_each(Fn&& fn) {
 }
 
 template <typename Tag_t, typename Key_t, typename Value_t>
-inline typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t*
+inline typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t
 SharedCache<Tag_t, Key_t, Value_t>::insert(Tag_t tag, Key_t key, uint32_t hash,
                                            bool pin) {
   assert(tenant_cache_map_.contains(tag));
-  Handle_t* e = lookup(key, hash, pin);
+  Node_t* e = lookup(key, hash, pin).node;
   if (e) return e;
 
   // The key does not exist in the cache, perform insertion
-  e = tenant_cache_map_[tag].insert(key, hash, pin, /*not_exist*/ true);
+  e = tenant_cache_map_[tag].insert(key, hash, pin, /*not_exist*/ true).node;
   if (!e) return nullptr;
-  e->value.tag = tag;
+  e->tag = tag;
   return e;
 }
 
 template <typename Tag_t, typename Key_t, typename Value_t>
-inline typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t*
+inline typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t
 SharedCache<Tag_t, Key_t, Value_t>::lookup(Key_t key, uint32_t hash, bool pin) {
-  Handle_t* e = table_.lookup(key, hash);
+  Node_t* e = table_.lookup(key, hash);
   if (!e) return nullptr;
 
-  Tag_t tag = get_tag(e);
+  Tag_t tag = e->tag;
   assert(tenant_cache_map_.contains(tag));
   tenant_cache_map_[tag].try_refresh(e, pin);
   return e;
@@ -143,24 +133,24 @@ SharedCache<Tag_t, Key_t, Value_t>::lookup(Key_t key, uint32_t hash, bool pin) {
 
 template <typename Tag_t, typename Key_t, typename Value_t>
 void SharedCache<Tag_t, Key_t, Value_t>::release(
-    typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t* handle) {
-  Tag_t tag = handle->value.tag;
+    typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t handle) {
+  Tag_t tag = handle.node->tag;
   assert(tenant_cache_map_.contains(tag));
   tenant_cache_map_[tag].release(handle);
 }
 
 template <typename Tag_t, typename Key_t, typename Value_t>
 void SharedCache<Tag_t, Key_t, Value_t>::pin(
-    typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t* handle) {
-  Tag_t tag = handle->value.tag;
+    typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t handle) {
+  Tag_t tag = handle.node->tag;
   assert(tenant_cache_map_.contains(tag));
   tenant_cache_map_[tag].pin(handle);
 }
 
 template <typename Tag_t, typename Key_t, typename Value_t>
 void SharedCache<Tag_t, Key_t, Value_t>::evict(
-    typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t* handle) {
-  Tag_t tag = handle->value.tag;
+    typename SharedCache<Tag_t, Key_t, Value_t>::Handle_t handle) {
+  Tag_t tag = handle.node->tag;
   assert(tenant_cache_map_.contains(tag));
   tenant_cache_map_[tag].evict(handle);
 }


### PR DESCRIPTION
```
// Use LRUHandle for public APIs as it's easier to access the value.
// Use LRUNode* for internal APIs as it's easier to access internal fields.
```