### PR TITLE
Support querying the size of a LRU cache

### DIFF
--- a/include/gcache/shared_cache.h
+++ b/include/gcache/shared_cache.h
@@ -89,6 +89,9 @@ class SharedCache {
   template <typename Fn>
   void for_each(Fn&& fn);
 
+  // For all APIs taking a tag as input, the tag must be valid (i.e., exists in
+  // tenant_configs); the behavior is undefined if not.
+
   // Insert a handle into cache with given key and hash if not exists; if does,
   // return the existing one
   Handle_t insert(Tag_t tag, Key_t key, bool pin = false,
@@ -114,6 +117,9 @@ class SharedCache {
   // Similar to LRUCache erase/install
   bool erase(Handle_t handle);
   Handle_t install(Tag_t tag, Key_t key);
+
+  // Return a read-only access to the LRU cache associated with the tag
+  const LRUCache<Key_t, TaggedValue_t, Hash>& get_cache(Tag_t tag);
 
  private:
   Node_t* lookup_impl(Key_t key, uint32_t hash, bool pin);
@@ -262,6 +268,15 @@ SharedCache<Tag_t, Key_t, Value_t, Hash>::install(Tag_t tag, Key_t key) {
   Handle_t h(e);
   h.set_tag(tag);
   return h;
+}
+
+template <typename Tag_t, typename Key_t, typename Value_t, typename Hash>
+inline const LRUCache<
+    Key_t, typename SharedCache<Tag_t, Key_t, Value_t, Hash>::TaggedValue_t,
+    Hash>&
+SharedCache<Tag_t, Key_t, Value_t, Hash>::get_cache(Tag_t tag) {
+  assert(tenant_cache_map_.contains(tag));
+  return tenant_cache_map_[tag];
 }
 
 template <typename Tag_t, typename Key_t, typename Value_t, typename Hash>

--- a/tests/test_lru.cpp
+++ b/tests/test_lru.cpp
@@ -19,34 +19,42 @@ struct hash2 {
 void test() {
   LRUCache<uint32_t, uint32_t, hash1> cache;
   cache.init(4);
+  assert(cache.size() == 0);
 
   auto h1 = cache.insert(1, true);
   assert(h1);
+  assert(cache.size() == 1);
   *h1 = 111;
   auto h2 = cache.insert(2, true);
   assert(h2);
+  assert(cache.size() == 2);
   *h1 = 222;
   auto h3 = cache.insert(3, true);
   assert(h3);
+  assert(cache.size() == 3);
   *h1 = 333;
   auto h4 = cache.insert(4);
   assert(h4);
+  assert(cache.size() == 4);
   *h1 = 444;
   std::cout << "=== Expect: lru: [4], in_use: [1, 2, 3] ===\n";
   std::cout << cache;
 
   h4 = cache.lookup(4, true);
   *h4 = 4444;
+  assert(cache.size() == 4);
   std::cout << "=== Expect: lru: [], in_use: [1, 2, 3, 4] ===\n";
   std::cout << cache;
 
   auto h5 = cache.insert(5, true);
   if (h5 != nullptr)
     throw std::runtime_error("Overflow insertion is not denied!");
+  assert(cache.size() == 4);
 
   cache.release(h3);
   h5 = cache.insert(5, true);
   assert(h5);
+  assert(cache.size() == 4);
   *h5 = 555;
   std::cout << "\n=== Expect: in_use: [1, 2, 4, 5] ===\n";
   std::cout << cache;
@@ -54,35 +62,42 @@ void test() {
   cache.release(h5);
   cache.release(h2);
   cache.release(h4);
+  assert(cache.size() == 4);
   std::cout << "\n=== Expect: lru: [5, 2, 4], in_use: [1] ===\n";
   std::cout << cache;
 
   h3 = cache.insert(3, true);
   assert(h3);
+  assert(cache.size() == 4);
   *h3 = 3333;
   h5 = cache.lookup(5, true);
+  assert(cache.size() == 4);
   std::cout << "\n=== Expect: lru: [2, 4], in_use: [1, 3] ===\n";
   std::cout << cache;
   if (h5 != nullptr)
     throw std::runtime_error("Expected evicted handle remains in cache!");
 
   h5 = cache.insert(5, true);
+  assert(cache.size() == 4);
   std::cout << "\n=== Expect: lru: [4], in_use: [1, 3, 5] ===\n";
   std::cout << cache;
 
   auto h6 = cache.insert(6, true);
   assert(h6);
+  assert(cache.size() == 4);
   *h6 = 666;
   std::cout << "\n=== Expect: lru: [], in_use: [1, 3, 5, 6] ===\n";
   std::cout << cache;
 
   auto h5_ = cache.insert(5, true);
   assert(h5_ == h5);
+  assert(cache.size() == 4);
   *h5_ = 555;
   std::cout << "\n=== Expect: lru: [], in_use: [1, 3, 5, 6] ===\n";
   std::cout << cache;
 
   auto h7 = cache.insert(7, true);
+  assert(cache.size() == 4);
   std::cout << "\n=== Expect: lru: [], in_use: [1, 3, 5, 6] ===\n";
   std::cout << cache;
   if (h7) throw std::runtime_error("Overflow handle is not denied!");
@@ -91,10 +106,12 @@ void test() {
   cache.release(h3);
   cache.release(h5);
   cache.release(h6);
+  assert(cache.size() == 4);
   std::cout << "\n=== Expect: lru: [1, 3, 6], in_use: [5] ===\n";
   std::cout << cache;
 
   cache.release(h5_);
+  assert(cache.size() == 4);
   std::cout << "\n=== Expect: lru: [1, 3, 6, 5], in_use: [] ===\n";
   std::cout << cache;
 
@@ -103,6 +120,7 @@ void test() {
 
   h7 = cache.insert(7);
   assert(h7);
+  assert(cache.size() == 4);
   *h7 = 777;
   std::cout << "\n=== Expect: lru: [3, 6, 5, 7], in_use: [] ===\n";
   std::cout << cache;
@@ -110,11 +128,13 @@ void test() {
   // test erase/install
   bool success = cache.erase(h7);
   assert(success);
+  assert(cache.size() == 3);
   std::cout << "\n=== Expect: lru: [3, 6, 5], in_use: [] ===\n";
   std::cout << cache;
 
   h6 = cache.lookup(6, true);
   assert(h6);
+  assert(cache.size() == 3);
   std::cout << "\n=== Expect: lru: [3, 5], in_use: [6] ===\n";
   std::cout << cache;
   success = cache.erase(h6);
@@ -122,11 +142,13 @@ void test() {
 
   auto h8 = cache.insert(8);
   *h8 = 888;
+  assert(cache.size() == 3);
   std::cout << "\n=== Expect: lru: [5, 8], in_use: [6] ===\n";
   std::cout << cache;
 
   auto h9 = cache.install(9);
   assert(h9);
+  assert(cache.size() == 4);
   *h9 = 999;
   std::cout << "\n=== Expect: lru: [5, 8, 9], in_use: [6] ===\n";
   std::cout << cache;

--- a/tests/test_shared.cpp
+++ b/tests/test_shared.cpp
@@ -18,6 +18,9 @@ void test1() {
 
   shared_cache.init(tenant_configs);
 
+  [[maybe_unused]] auto& cache_537 = shared_cache.get_cache(537);
+  [[maybe_unused]] auto& cache_564 = shared_cache.get_cache(564);
+
   auto h = shared_cache.insert(537, 1, true);
   assert(h);
   *h = 111;
@@ -28,8 +31,9 @@ void test1() {
   h = shared_cache.insert(537, 3, false);
   assert(h);
   *h = 333;
-
-  std::cout << "Expect: { 564: [2], 537: [1, 3]}" << std::endl;
+  assert(cache_537.size() == 2);
+  assert(cache_564.size() == 1);
+  std::cout << "Expect: { 537: [1, 3], 564: [2] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
   h = shared_cache.insert(564, 4, false);
@@ -38,7 +42,9 @@ void test1() {
   h = shared_cache.insert(537, 5, false);
   assert(h);
   *h = 555;
-  std::cout << "Expect: { 564: [2, 4], 537: [1, 3, 5] }" << std::endl;
+  assert(cache_537.size() == 3);
+  assert(cache_564.size() == 2);
+  std::cout << "Expect: { 537: [1, 3, 5], 564: [2, 4] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
   h = shared_cache.insert(564, 6, false);
@@ -47,7 +53,9 @@ void test1() {
   h = shared_cache.insert(537, 2, false);
   assert(h);
   *h = 2222;
-  std::cout << "Expect: { 564: [4, 6], 537: [3, 5, 2] }" << std::endl;
+  assert(cache_537.size() == 3);
+  assert(cache_564.size() == 2);
+  std::cout << "Expect: {  537: [3, 5, 2], 564: [4, 6] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
   // try to access a handle already in the other tenant's cache
@@ -55,11 +63,15 @@ void test1() {
   h = shared_cache.insert(564, 2, false);
   assert(h);
   *h = 22222;
-  std::cout << "Expect: { 564: [4, 6], 537: [3, 5, 2] }" << std::endl;
+  assert(cache_537.size() == 3);
+  assert(cache_564.size() == 2);
+  std::cout << "Expect: { 537: [3, 5, 2], 564: [4, 6] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
   shared_cache.relocate(537, 564, 2);
-  std::cout << "Expect: { 564: [4, 6], 537: [2] }" << std::endl;
+  assert(cache_537.size() == 1);
+  assert(cache_564.size() == 2);
+  std::cout << "Expect: { 537: [2], 564: [4, 6] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
   h = shared_cache.insert(564, 7, false);
@@ -68,26 +80,34 @@ void test1() {
   h = shared_cache.insert(564, 8, false);
   assert(h);
   *h = 888;
-  std::cout << "Expect: { 564: [4, 6, 7, 8], 537: [2] }" << std::endl;
+  assert(cache_537.size() == 1);
+  assert(cache_564.size() == 4);
+  std::cout << "Expect: { 537: [2], 564: [4, 6, 7, 8] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
   h = shared_cache.insert(564, 9, false);
   assert(h);
   *h = 999;
-  std::cout << "Expect: { 564: [6, 7, 8, 9], 537: [2] }" << std::endl;
+  assert(cache_537.size() == 1);
+  assert(cache_564.size() == 4);
+  std::cout << "Expect: { 537: [2], 564: [6, 7, 8, 9]}" << std::endl;
   std::cout << shared_cache << std::endl;
 
   // test erase/install
   [[maybe_unused]] bool success = shared_cache.erase(h);
   assert(success);
-  std::cout << "Expect: { 564: [6, 7, 8], 537: [2] }" << std::endl;
+  assert(cache_537.size() == 1);
+  assert(cache_564.size() == 3);
+  std::cout << "Expect: { 537: [2], 564: [6, 7, 8] }" << std::endl;
   std::cout << shared_cache << std::endl;
 
   // setting values is skipped...
   shared_cache.install(537, 10);
   shared_cache.install(537, 11);
   shared_cache.install(564, 12);
-  std::cout << "Expect: { 564: [6, 7, 8, 12], 537: [2, 10, 11] }" << std::endl;
+  assert(cache_537.size() == 3);
+  assert(cache_564.size() == 4);
+  std::cout << "Expect: { 537: [2, 10, 11], 564: [6, 7, 8, 12] }" << std::endl;
   std::cout << shared_cache << std::endl;
 }
 


### PR DESCRIPTION
Add `LRUCache::size()`; Add `SharedCache::get_cache()` to access the specific LRU cache underneath.