### PR TITLE
Use Reuse Distance Histogram for Cache Stat

### DIFF
--- a/include/gcache/ghost_cache.h
+++ b/include/gcache/ghost_cache.h
@@ -160,7 +160,7 @@ class GhostCache {
 
  public:
   std::ostream& print(std::ostream& os, int indent = 0);
-  friend std::ostream& operator<<(std::ostream& os, const GhostCache& c) {
+  friend std::ostream& operator<<(std::ostream& os, GhostCache& c) {
     return c.print(os);
   }
 };

--- a/include/gcache/ghost_kv_cache.h
+++ b/include/gcache/ghost_kv_cache.h
@@ -52,13 +52,13 @@ class SampledGhostKvCache {
   [[nodiscard]] uint32_t get_max_count() const {
     return ghost_cache.get_max_size();
   }
-  [[nodiscard]] double get_hit_rate(uint32_t count) const {
+  [[nodiscard]] double get_hit_rate(uint32_t count) {
     return ghost_cache.get_hit_rate(count);
   }
-  [[nodiscard]] double get_miss_rate(uint32_t count) const {
+  [[nodiscard]] double get_miss_rate(uint32_t count) {
     return ghost_cache.get_miss_rate(count);
   }
-  [[nodiscard]] const CacheStat& get_stat(uint32_t count) const {
+  [[nodiscard]] const CacheStat& get_stat(uint32_t count) {
     return ghost_cache.get_stat(count);
   }
 
@@ -90,7 +90,7 @@ class SampledGhostKvCache {
 
   [[nodiscard]] const std::vector<std::tuple<
       /*count*/ uint32_t, /*size*/ uint32_t, /*miss_rate*/ CacheStat>>
-  get_cache_stat_curve() const {
+  get_cache_stat_curve() {
     std::vector<std::tuple<uint32_t, uint32_t, CacheStat>> curve;
     uint32_t curr_count = 0;
     uint32_t curr_size = 0;


### PR DESCRIPTION
Instead of directly updating cache stats of all sizes, only maintain a histogram of reuse distances. This makes this operation complexity from O(n) to O(1) where n is the number of cache sizes tracked. Note the overhead of a ghost cache access is still O(n) due to the cost of maintaining boundaries.

This optimization improves the performance by ~10%.