### PR TITLE
Templated Numerical Type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cmake-build-*
 .idea
 .clangd
 compile_commands.json
+.cache

--- a/include/gcache/ghost_cache.h
+++ b/include/gcache/ghost_cache.h
@@ -64,7 +64,7 @@ class GhostCache {
 
   Handle_t access_impl(SizeType block_id, HashType hash, AccessMode mode);
 
-  template <uint32_t S, typename H>
+  template <uint32_t S, typename H, typename ST, typename HT>
   friend class SampledGhostKvCache;
 
   void build_caches_stat();
@@ -219,7 +219,7 @@ class SampledGhostCache : public GhostCache<Hash, Meta, SizeType, HashType> {
   }
 
  protected:
-  template <uint32_t S, typename H>
+  template <uint32_t S, typename H, typename ST, typename HT>
   friend class SampledGhostKvCache;
 
   [[nodiscard]] const CacheStat& get_stat_shifted(SizeType cache_size_shifted) {

--- a/include/gcache/ghost_cache.h
+++ b/include/gcache/ghost_cache.h
@@ -59,8 +59,8 @@ class GhostCache {
   std::vector<CacheStat> caches_stat;
 
   // the reused distances are formatted as a histogram
-  std::vector<uint64_t> reuse_distances;  // converted to caches_stat lazily
-  uint64_t reuse_count;                   // count all access to reuse_distances
+  std::vector<size_t> reuse_distances;  // converted to caches_stat lazily
+  size_t reuse_count;                   // count all access to reuse_distances
 
   Handle_t access_impl(SizeType block_id, HashType hash, AccessMode mode);
 
@@ -312,7 +312,7 @@ GhostCache<Hash, Meta, SizeType, HashType>::access_impl(SizeType block_id,
 
 template <typename Hash, typename Meta, typename SizeType, typename HashType>
 inline void GhostCache<Hash, Meta, SizeType, HashType>::build_caches_stat() {
-  uint64_t accum_hit_cnt = 0;
+  size_t accum_hit_cnt = 0;
   for (size_t idx = 0; idx < caches_stat.size(); ++idx) {
     accum_hit_cnt += reuse_distances[idx];
     caches_stat[idx].hit_cnt = accum_hit_cnt;

--- a/include/gcache/ghost_kv_cache.h
+++ b/include/gcache/ghost_kv_cache.h
@@ -6,9 +6,10 @@
 
 namespace gcache {
 
+template <typename SizeType = uint32_t>
 struct GhostKvMeta {
-  uint32_t size_idx;
-  uint32_t kv_size;
+  SizeType size_idx;
+  SizeType kv_size;
 };
 
 /**
@@ -16,29 +17,34 @@ struct GhostKvMeta {
  * pair can be variable-length. By default support sampling (non-sampling
  * version can be acquired by setting SampleShift=0)
  */
-template <uint32_t SampleShift = 5, typename Hash = std::hash<std::string_view>>
+template <uint32_t SampleShift = 5, typename Hash = std::hash<std::string_view>,
+          typename SizeType = uint32_t, typename HashType = uint32_t>
 class SampledGhostKvCache {
-  SampledGhostCache<SampleShift, idhash, GhostKvMeta> ghost_cache;
+  SampledGhostCache<SampleShift, idhash, GhostKvMeta<SizeType>, SizeType,
+                    HashType>
+      ghost_cache;
 
  public:
   using Handle_t =
-      typename SampledGhostCache<SampleShift, idhash, GhostKvMeta>::Handle_t;
+      typename SampledGhostCache<SampleShift, idhash, GhostKvMeta<SizeType>,
+                                 SizeType, HashType>::Handle_t;
   using Node_t =
-      typename SampledGhostCache<SampleShift, idhash, GhostKvMeta>::Node_t;
+      typename SampledGhostCache<SampleShift, idhash, GhostKvMeta<SizeType>,
+                                 SizeType, HashType>::Node_t;
 
  public:
-  SampledGhostKvCache(uint32_t tick, uint32_t min_count, uint32_t max_count)
+  SampledGhostKvCache(SizeType tick, SizeType min_count, SizeType max_count)
       : ghost_cache(tick, min_count, max_count) {
     static_assert(SampleShift <= 32, "SampleShift must be no larger than 32");
   }
 
-  void access(const std::string_view key, uint32_t kv_size,
+  void access(const std::string_view key, SizeType kv_size,
               AccessMode mode = AccessMode::DEFAULT) {
-    uint32_t key_hash = Hash{}(key);
+    HashType key_hash = Hash{}(key);
     access(key_hash, kv_size, mode);
   }
 
-  void access(uint32_t key_hash, uint32_t kv_size,
+  void access(HashType key_hash, SizeType kv_size,
               AccessMode mode = AccessMode::DEFAULT) {
     // only with certain number of leading zeros is sampled
     if constexpr (SampleShift > 0) {
@@ -49,20 +55,20 @@ class SampledGhostKvCache {
   }
 
   // for compatibility with GhostCache: APIs to query by keys count
-  [[nodiscard]] uint32_t get_tick() const { return ghost_cache.get_tick(); }
-  [[nodiscard]] uint32_t get_min_count() const {
+  [[nodiscard]] SizeType get_tick() const { return ghost_cache.get_tick(); }
+  [[nodiscard]] SizeType get_min_count() const {
     return ghost_cache.get_min_size();
   }
-  [[nodiscard]] uint32_t get_max_count() const {
+  [[nodiscard]] SizeType get_max_count() const {
     return ghost_cache.get_max_size();
   }
-  [[nodiscard]] double get_hit_rate(uint32_t count) {
+  [[nodiscard]] double get_hit_rate(SizeType count) {
     return ghost_cache.get_hit_rate(count);
   }
-  [[nodiscard]] double get_miss_rate(uint32_t count) {
+  [[nodiscard]] double get_miss_rate(SizeType count) {
     return ghost_cache.get_miss_rate(count);
   }
-  [[nodiscard]] const CacheStat& get_stat(uint32_t count) {
+  [[nodiscard]] const CacheStat& get_stat(SizeType count) {
     return ghost_cache.get_stat(count);
   }
 
@@ -92,12 +98,14 @@ class SampledGhostKvCache {
     ghost_cache.for_each_until_mru(fn);
   }
 
+  // the aggregated kv_size can easiler grow beyond 4 GB, so we use size_t
+  // instead of SizeType for that.
   [[nodiscard]] const std::vector<std::tuple<
-      /*count*/ uint32_t, /*size*/ uint32_t, /*miss_rate*/ CacheStat>>
+      /*count*/ SizeType, /*size*/ size_t, /*miss_rate*/ CacheStat>>
   get_cache_stat_curve() {
-    std::vector<std::tuple<uint32_t, uint32_t, CacheStat>> curve;
-    uint32_t curr_count = 0;
-    uint32_t curr_size = 0;
+    std::vector<std::tuple<SizeType, size_t, CacheStat>> curve;
+    SizeType curr_count = 0;
+    size_t curr_size = 0;
     ghost_cache.unsafe_for_each_mru([&](Handle_t h) {
       curr_size += h->kv_size;
       ++curr_count;

--- a/include/gcache/ghost_kv_cache.h
+++ b/include/gcache/ghost_kv_cache.h
@@ -98,8 +98,8 @@ class SampledGhostKvCache {
     ghost_cache.for_each_until_mru(fn);
   }
 
-  // the aggregated kv_size can easiler grow beyond 4 GB, so we use size_t
-  // instead of SizeType for that.
+  // Since the aggregated kv_size can easiler grow beyond 4 GB, we use size_t
+  // instead of SizeType for that
   [[nodiscard]] const std::vector<std::tuple<
       /*count*/ SizeType, /*size*/ size_t, /*miss_rate*/ CacheStat>>
   get_cache_stat_curve() {

--- a/include/gcache/lru_cache.h
+++ b/include/gcache/lru_cache.h
@@ -15,7 +15,7 @@
 
 namespace gcache {
 
-template <typename Hash, typename Meta>
+template <typename Hash, typename Meta, typename SizeType, typename HashType>
 class GhostCache;
 
 template <typename Tag_t, typename Key_t, typename Value_t, typename Hash>
@@ -199,7 +199,7 @@ class LRUCache {
   // Pool for additionaly allocated handles.
   std::vector<Node_t*> extra_pool_;
 
-  template <typename H, typename M>
+  template <typename H, typename M, typename ST, typename HT>
   friend class GhostCache;
 
   template <typename T, typename K, typename V, typename H>

--- a/include/gcache/node.h
+++ b/include/gcache/node.h
@@ -33,7 +33,7 @@ class NodeTable;
 template <typename Key_t, typename Value_t, typename Hash>
 class LRUCache;
 
-template <typename Hash, typename Meta>
+template <typename Hash, typename Meta, typename SizeType, typename HashType>
 class GhostCache;
 
 // LRUNodes forms a circular doubly linked list ordered by access time.
@@ -50,7 +50,7 @@ class LRUNode {
   template <typename K, typename V, typename H>
   friend class LRUCache;
 
-  template <typename H, typename M>
+  template <typename H, typename M, typename ST, typename HT>
   friend class GhostCache;
 
  public:
@@ -140,7 +140,7 @@ class LRUHandle : public BaseHandle<LRUNode<Key_t, Value_t>> {
   template <typename K, typename V, typename H>
   friend class LRUCache;
 
-  template <typename H, typename M>
+  template <typename H, typename M, typename ST, typename HT>
   friend class GhostCache;
 
  public:

--- a/include/gcache/stat.h
+++ b/include/gcache/stat.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <cstdint>
 #include <iomanip>
 #include <limits>
 
 namespace gcache {
 
 struct CacheStat {
-  uint64_t hit_cnt;
-  uint64_t miss_cnt;
+  size_t hit_cnt;
+  size_t miss_cnt;
 
  public:
   CacheStat() : hit_cnt(0), miss_cnt(0) {}
@@ -20,13 +19,13 @@ struct CacheStat {
   // e.g., hit_rate > 100%.
   // we don't use atomic here because we find it is too expensive.
   [[nodiscard]] double get_hit_rate() const {
-    uint64_t acc_cnt = hit_cnt + miss_cnt;
+    size_t acc_cnt = hit_cnt + miss_cnt;
     if (acc_cnt == 0) return std::numeric_limits<double>::infinity();
     return double(hit_cnt) / double(acc_cnt);
   }
 
   [[nodiscard]] double get_miss_rate() const {
-    uint64_t acc_cnt = hit_cnt + miss_cnt;
+    size_t acc_cnt = hit_cnt + miss_cnt;
     if (acc_cnt == 0) return std::numeric_limits<double>::infinity();
     return double(miss_cnt) / double(acc_cnt);
   }
@@ -37,7 +36,7 @@ struct CacheStat {
   }
 
   std::ostream& print(std::ostream& os, int width = 0) const {
-    uint64_t acc_cnt = hit_cnt + miss_cnt;
+    size_t acc_cnt = hit_cnt + miss_cnt;
     if (acc_cnt == 0)
       return os << "  NAN (" << std::setw(width) << std::fixed << hit_cnt << '/'
                 << std::setw(width) << std::fixed << acc_cnt << ')';

--- a/tests/test_ghost_kv.cpp
+++ b/tests/test_ghost_kv.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <string>
 
+#include "gcache/ghost_cache.h"
 #include "gcache/ghost_kv_cache.h"
 #include "gcache/node.h"
 #include "util.h"
@@ -30,11 +31,10 @@ void bench1() {
   std::vector<uint32_t> reqs;
   std::vector<std::pair<uint32_t, std::string>> reqs2;
   for (uint32_t i = 0; i < bench_size; ++i) {
-    ghost_cache.access(i);
-    sampled_ghost_kv_cache.access(make_key(i), i > bench_size / 4 ? 500 : 2000);
+    ghost_cache.access(i, AccessMode::NOOP);
+    sampled_ghost_kv_cache.access(make_key(i), i > bench_size / 4 ? 500 : 2000,
+                                  AccessMode::NOOP);
   }
-  ghost_cache.reset_stat();
-  sampled_ghost_kv_cache.reset_stat();
 
   for (uint32_t i = 0; i < num_ops; ++i) reqs.emplace_back(rand() % bench_size);
   std::random_shuffle(reqs.begin(), reqs.end());
@@ -53,12 +53,12 @@ void bench1() {
   std::cout << "=== Bench 1 ===\n";
   std::cout << "w/o sampling: " << elapse_g / num_ops << " cycles/op\n";
   std::cout << "w/ sampling:  " << elapse_s / num_ops << " cycles/op\n";
-  std::cout << "========================= Hit Rate ==========================="
-            << "======================\n"
-            << " size |       w/o sampling       |        w/ sampling       |"
-            << "        kv memoy       \n"
-            << "-------------------------------------------------------------"
-            << "-----------------------\n";
+  std::cout << "==================================== Hit Rate ==============="
+               "=======================\n"
+               " size |       w/o sampling       |        w/ sampling       |"
+               "        kv memoy       \n"
+               "-------------------------------------------------------------"
+               "-----------------------\n";
 
   auto curve = sampled_ghost_kv_cache.get_cache_stat_curve();
   for (uint32_t s = tick; s <= bench_size; s += tick) {


### PR DESCRIPTION
Support customized numerical type in the class template. In general, the numerical assumption is:
- To count the number of accesses, use `size_t`.
- To sum up the total memory of a key-value cache, use `size_t`. This should not be `uint32_t` because it can easily grow over 4 GB.
- The size of a single key-value pair, use `uint32_t` by default, but can be customized in the template as `SizeType`. A single key-value pair should not be larger than 4 GB, and we prefer to make the per-key metadata compacted.
- The type of hash is `uint32_t` by default, because we don't need as many bits, but it can be customized in the template as `HashType`.